### PR TITLE
GRAPHITE-PAGER http-timeouts-from-env

### DIFF
--- a/graphitepager/graphite_target.py
+++ b/graphitepager/graphite_target.py
@@ -8,9 +8,9 @@ def get_records(base_url,
                 http_connect_timeout_s_ = 0.1,
                 http_read_timeout_s_    = 1.0):
     url = _graphite_url_for_target(base_url, target, from_=from_, until_=until_)
-    print "url:                     %s" % [url]
-    print "http_connect_timeout_s_: %f" % [http_connect_timeout_s_]
-    print "http_read_timeout_s_:    %f" % [http_read_timeout_s_]
+    print "url:                     %s" % url
+    print "http_connect_timeout_s_: %f" % http_connect_timeout_s_
+    print "http_read_timeout_s_:    %f" % http_read_timeout_s_
     resp = http_get(
         url,
         verify  = True,

--- a/graphitepager/graphite_target.py
+++ b/graphitepager/graphite_target.py
@@ -3,10 +3,10 @@ def get_records(base_url,
                 http_get,
                 data_record,
                 target,
-                from_='-1min',
-                until_=None,
-                http_connect_timeout_s_=0.1,
-                http_connect_timeout_s_=1.0):
+                from_                   = '-1min',
+                until_                  = None,
+                http_connect_timeout_s_ = 0.1,
+                http_read_timeout_s_    = 1.0):
     url = _graphite_url_for_target(base_url, target, from_=from_, until_=until_)
     print "url:                     %s" % [url]
     print "http_connect_timeout_s_: %f" % [http_connect_timeout_s_]

--- a/graphitepager/graphite_target.py
+++ b/graphitepager/graphite_target.py
@@ -8,9 +8,6 @@ def get_records(base_url,
                 http_connect_timeout_s_ = 0.1,
                 http_read_timeout_s_    = 1.0):
     url = _graphite_url_for_target(base_url, target, from_=from_, until_=until_)
-    print "url:                     %s" % url
-    print "http_connect_timeout_s_: %f" % http_connect_timeout_s_
-    print "http_read_timeout_s_:    %f" % http_read_timeout_s_
     resp = http_get(
         url,
         verify  = True,

--- a/graphitepager/graphite_target.py
+++ b/graphitepager/graphite_target.py
@@ -1,10 +1,14 @@
 
-def get_records(base_url, http_get, data_record, target, **kwargs):
-    url = _graphite_url_for_target(base_url, target, **kwargs)
-    http_connect_timeout_s_ = kwargs['http_connect_timeout_s_'],
-    http_read_timeout_s_    = kwargs['http_read_timeout_s_'],
+def get_records(base_url,
+                http_get,
+                data_record,
+                target,
+                from_='-1min',
+                until_=None,
+                http_connect_timeout_s_=0.1,
+                http_connect_timeout_s_=1.0):
+    url = _graphite_url_for_target(base_url, target, from_=from_, until_=until_)
     print "url:                     %s" % [url]
-    print "kargs:                   %s" % [kwargs]
     print "http_connect_timeout_s_: %f" % [http_connect_timeout_s_]
     print "http_read_timeout_s_:    %f" % [http_read_timeout_s_]
     resp = http_get(

--- a/graphitepager/graphite_target.py
+++ b/graphitepager/graphite_target.py
@@ -1,7 +1,17 @@
 
 def get_records(base_url, http_get, data_record, target, **kwargs):
     url = _graphite_url_for_target(base_url, target, **kwargs)
-    resp = http_get(url, verify=True)
+    http_connect_timeout_s_ = kwargs['http_connect_timeout_s_'],
+    http_read_timeout_s_    = kwargs['http_read_timeout_s_'],
+    print "url:                     %s" % [url]
+    print "kargs:                   %s" % [kwargs]
+    print "http_connect_timeout_s_: %f" % [http_connect_timeout_s_]
+    print "http_read_timeout_s_:    %f" % [http_read_timeout_s_]
+    resp = http_get(
+        url,
+        verify  = True,
+        timeout = (http_connect_timeout_s_,http_read_timeout_s_),
+    )
     resp.raise_for_status()
     records = []
     for line in resp.content.split('\n'):

--- a/graphitepager/worker.py
+++ b/graphitepager/worker.py
@@ -120,10 +120,11 @@ def run(args):
                     http_connect_timeout_s_ = http_connect_timeout_s,
                     http_read_timeout_s_    = http_read_timeout_s,
                 )
-            except requests.exceptions.RequestException:
+            except requests.exceptions.RequestException as e:
                 if not alert.alert_data['allow_no_data']:
                     print "Error, {0}".format(alert.alert_data)
                     update_notifiers_missing(notifier_proxy, alert, config)
+                print "Exception: %s" % e
                 records = []
 
             for record in records:

--- a/graphitepager/worker.py
+++ b/graphitepager/worker.py
@@ -100,6 +100,8 @@ def run(args):
     notifier_proxy = create_notifier_proxy(config)
     graphite_url = config.get('GRAPHITE_URL')
     heartbeat_seconds = config.get('HEARTBEAT_SECONDS','60')
+    http_connect_timeout_s = int(config.get('GRAPHITE_CONNECT_TIMEOUT_S','0.5'))
+    http_read_timeout_s    = int(config.get('GRAPHITE_READ_TIMEOUT_S',   '10'))
     while True:
         start_time = time.time()
         seen_alert_targets = set()
@@ -113,6 +115,8 @@ def run(args):
                     target,
                     from_=alert.get('from'),
                     until_=alert.get('until'),
+                    http_connect_timeout_s_ = http_connect_timeout_s,
+                    http_read_timeout_s_    = http_read_timeout_s,
                 )
             except requests.exceptions.RequestException:
                 if not alert.alert_data['allow_no_data']:

--- a/graphitepager/worker.py
+++ b/graphitepager/worker.py
@@ -100,8 +100,10 @@ def run(args):
     notifier_proxy = create_notifier_proxy(config)
     graphite_url = config.get('GRAPHITE_URL')
     heartbeat_seconds = config.get('HEARTBEAT_SECONDS','60')
-    http_connect_timeout_s = int(config.get('GRAPHITE_CONNECT_TIMEOUT_S','0.5'))
-    http_read_timeout_s    = int(config.get('GRAPHITE_READ_TIMEOUT_S',   '10'))
+    http_connect_timeout_s = config.get('GRAPHITE_CONNECT_TIMEOUT_S','0.5')
+    http_read_timeout_s    = config.get('GRAPHITE_READ_TIMEOUT_S',   '10')
+    http_connect_timeout_s = float(http_connect_timeout_s)
+    http_read_timeout_s    = float(http_read_timeout_s)
     while True:
         start_time = time.time()
         seen_alert_targets = set()


### PR DESCRIPTION
Support ENV vars `GRAPHITE_CONNECT_TIMEOUT_S` and `GRAPHITE_READ_TIMEOUT_S` in hopes of better-managing the `NO DATA` warnings which we get sometimes when long-running Graphite queries get slow.