### PR TITLE
ALI-20527: Update HostedGraphite dashboard name in grafana_url

### DIFF
--- a/graphitepager/description.py
+++ b/graphitepager/description.py
@@ -146,7 +146,7 @@ class Description(object):
 
         grafana_url = 'https://www.hostedgraphite.com' \
                       + path \
-                      + '/grafana/dashboard/db/watchman'
+                      + '/grafana/dashboard/db/ali-production-watchman'
         context['grafana_url'] = grafana_url
 
         context['threshold_value'] = alert.value_for_level(level)


### PR DESCRIPTION
the existing link here is wrong. example slack msg: https://prosperworks.slack.com/archives/C0ADKJJJJ/p1718034283941059

'Grafana' contains https://www.hostedgraphite.com/b372ff29/grafana/dashboard/db/watchman which lands you here after a redirect: https://www.hostedgraphite.com/b372ff29/grafana/d/000000012/watchman?orgId=2&refresh=1m

the simplest way i could fix this was changing 'watchman' to the right dashboard name 'ali-production-watchman' and some other magical redirect seems to save the day

https://www.hostedgraphite.com/b372ff29/grafana/dashboard/db/ali-production-watchman -> https://www.hostedgraphite.com/b372ff29/grafana/d/wsQ5EI_Mk/ali-production-watchman?orgId=2&refresh=5m