### PR TITLE
update grafana url so that our path is in subdomain

### DIFF
--- a/graphitepager/description.py
+++ b/graphitepager/description.py
@@ -144,9 +144,11 @@ class Description(object):
         while os.path.dirname(path) != '/':
             path = os.path.dirname(path)
 
-        grafana_url = 'https://www.hostedgraphite.com' \
+        grafana_url = 'https://' \
                       + path \
-                      + '/grafana/dashboard/db/ali-production-watchman'
+                      + '.hostedgraphite.com/d/' \
+                      + 'bd9883de-1f24-47d8-ba91-5672ed8ff4b9/' \
+                      + 'ali-production-watchman'
         context['grafana_url'] = grafana_url
 
         context['threshold_value'] = alert.value_for_level(level)


### PR DESCRIPTION
<img width="737" alt="Screenshot 2024-09-24 at 9 21 17 AM" src="https://github.com/user-attachments/assets/2312a6e4-4dde-43ae-b0ff-786ef3151cae">

Our Slack alerts, example above, give us a quick link to the Watchman dashboard and a PNG image of the graph that's in warning or critical status. HostedGraphite has updated their address structure so that our organization identifier is not just a directory under www.hostedgraphite.com, but a subdomain of hostedgraphite.com.
![Screenshot 2024-09-24 at 9 50 09 AM](https://github.com/user-attachments/assets/de8a71af-869e-429e-a9d4-dfd9e819627f)

This change updates the grafana_url variable in accordance to HostedGraphite's update.

TLDR; 
https://www.hostedgraphite.com/b372ff29/grafana/dashboard/db/ali-production-watchman -> https://b372ff29.hostedgraphite.com/d/bd9883de-1f24-47d8-ba91-5672ed8ff4b9/ali-production-watchman