### PR TITLE
remove a single slash from the url after https://

### DIFF
--- a/graphitepager/description.py
+++ b/graphitepager/description.py
@@ -144,7 +144,7 @@ class Description(object):
         while os.path.dirname(path) != '/':
             path = os.path.dirname(path)
 
-        grafana_url = 'https://' \
+        grafana_url = 'https:/' \
                       + path \
                       + '.hostedgraphite.com/d/' \
                       + 'bd9883de-1f24-47d8-ba91-5672ed8ff4b9/' \


### PR DESCRIPTION
<img width="409" alt="Screenshot 2025-01-01 at 5 39 59 AM" src="https://github.com/user-attachments/assets/d715f3a0-fc68-458e-8c9f-1dd03bf11ed0" />

Links to Hosted Graphite Dashboard are broken with extra '/' after https: