### PR TITLE
bump kinja2 and markupsafe python modules for heroku-22 compatibiity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Jinja2==2.8
-MarkupSafe==0.23
+Jinja2==3.0.0
+MarkupSafe==3.0.0
 pushbullet.py==0.10.0
 python-magic==0.4.12
 python-simple-hipchat==0.4.0


### PR DESCRIPTION
To be consumed with https://github.com/ProsperWorks/ALI-watchman/pull/710

Heroku-22 requires us to be on Python 3.10 at minimum. With this, Kinja2 and MarkupSafe need to also get upgraded